### PR TITLE
Fix comma-seperated selectors in nesting

### DIFF
--- a/dicss.js
+++ b/dicss.js
@@ -21,7 +21,7 @@
                     value = rule[property];
                     if (value instanceof Object) {
                         property = (/^:|&/.test(property) ? '' : ' ') + property.replace('&', '');
-						property = property.replace(/,\s?/g, ', ' + selector + ' ');
+                        property = property.replace(/,\s?/g, ', ' + selector + ' ');
                         addRule(selector + property, value);
                         continue;
                     }

--- a/dicss.js
+++ b/dicss.js
@@ -21,7 +21,8 @@
                     value = rule[property];
                     if (value instanceof Object) {
                         property = (/^:|&/.test(property) ? '' : ' ') + property.replace('&', '');
-                        addRule(selector + property.replace(/,\s?/g, ', ' + selector + ' '), value);
+						property = property.replace(/,\s?/g, ', ' + selector + ' ');
+                        addRule(selector + property, value);
                         continue;
                     }
                     rules += property + ':' + value + ';';

--- a/dicss.js
+++ b/dicss.js
@@ -21,7 +21,7 @@
                     value = rule[property];
                     if (value instanceof Object) {
                         property = (/^:|&/.test(property) ? '' : ' ') + property.replace('&', '');
-                        addRule(selector + property, value);
+                        addRule(selector + property.replace(/,\s?/g, ', ' + selector + ' '), value);
                         continue;
                     }
                     rules += property + ':' + value + ';';


### PR DESCRIPTION
I noticed that when using multiple selectors (comma separated) in children, it didn't work quite as intended.

For example

    DICSS.putIn("section", {
        "h1, h2": {
            "color": "red"
        }
    });

Would result in

    section h1, h2 {
        color: red
    }

as opposed to

    section h1, section h2 {
        color: red
    }

So I fixed this as best I could